### PR TITLE
.github: update go build matrix

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.15', '1.14', '1.13', '1.12', '1.11']
+        go: ['1.17', '1.16', '1.15', '1.11']
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
Drop some older versions, but keep 1.11 for legacy purposes.